### PR TITLE
Fixes for various Nix 2.3 concurrency issues

### DIFF
--- a/src/libexpr/nix-expr.pc.in
+++ b/src/libexpr/nix-expr.pc.in
@@ -7,4 +7,4 @@ Description: Nix Package Manager
 Version: @PACKAGE_VERSION@
 Requires: nix-store bdw-gc
 Libs: -L${libdir} -lnixexpr
-Cflags: -I${includedir}/nix -std=c++17
+Cflags: -I${includedir}/nix -std=c++20

--- a/src/libmain/nix-main.pc.in
+++ b/src/libmain/nix-main.pc.in
@@ -6,4 +6,4 @@ Name: Nix
 Description: Nix Package Manager
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lnixmain
-Cflags: -I${includedir}/nix -std=c++17
+Cflags: -I${includedir}/nix -std=c++20

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3874,7 +3874,7 @@ private:
     Pipe outPipe;
 
     /* The substituter thread. */
-    std::thread thr;
+    std::jthread thr;
 
     std::promise<void> promise;
 
@@ -4104,7 +4104,7 @@ void SubstitutionGoal::tryToRun()
 
     promise = std::promise<void>();
 
-    thr = std::thread([this]() {
+    thr = std::jthread([this]() {
         try {
             /* Wake up the worker loop when we're done. */
             Finally updateStats([this]() { outPipe.writeSide.close(); });

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -545,9 +545,10 @@ bool UserLock::findFreeUser() {
 
     /* Get the members of the build-users-group. */
     struct group * gr = getgrnam(settings.buildUsersGroup.get().c_str());
-    if (!gr)
+    if (!gr) {
         throw Error(format("the group '%1%' specified in 'build-users-group' does not exist")
             % settings.buildUsersGroup);
+    }
     gid = gr->gr_gid;
 
     /* Copy the result of getgrnam. */
@@ -557,65 +558,77 @@ bool UserLock::findFreeUser() {
         users.push_back(*p);
     }
 
-    if (users.empty())
+    if (users.empty()) {
         throw Error(format("the build users group '%1%' has no members")
             % settings.buildUsersGroup);
+    }
 
     /* Find a user account that isn't currently in use for another
        build. */
     for (auto & i : users) {
         debug(format("trying user '%1%'") % i);
 
-        struct passwd * pw = getpwnam(i.c_str());
-        if (!pw)
+        struct passwd* pw = getpwnam(i.c_str());
+        if (!pw) {
             throw Error(format("the user '%1%' in the group '%2%' does not exist")
                 % i % settings.buildUsersGroup);
-
+        }
 
         fnUserLock = (format("%1%/userpool/%2%") % settings.nixStateDir % pw->pw_uid).str();
 
+        bool inserted = false;
         {
             auto lockedPaths(lockedPaths_.lock());
-            if (lockedPaths->count(fnUserLock))
+            if (lockedPaths->count(fnUserLock)) {
                 /* We already have a lock on this one. */
                 continue;
+            }
             lockedPaths->insert(fnUserLock);
+            inserted = true;
         }
 
         try {
-
             AutoCloseFD fd = open(fnUserLock.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0600);
-            if (!fd)
+            if (!fd) {
                 throw SysError(format("opening user lock '%1%'") % fnUserLock);
-
-            if (lockFile(fd.get(), ltWrite, false)) {
-                fdUserLock = std::move(fd);
-                user = i;
-                uid = pw->pw_uid;
-
-                /* Sanity check... */
-                if (uid == getuid() || uid == geteuid())
-                    throw Error(format("the Nix user should not be a member of '%1%'")
-                        % settings.buildUsersGroup);
-
-#if __linux__
-                /* Get the list of supplementary groups of this build user.  This
-                   is usually either empty or contains a group such as "kvm".  */
-                supplementaryGIDs.resize(10);
-                int ngroups = supplementaryGIDs.size();
-                int err = getgrouplist(pw->pw_name, pw->pw_gid,
-                    supplementaryGIDs.data(), &ngroups);
-                if (err == -1)
-                    throw Error(format("failed to get list of supplementary groups for '%1%'") % pw->pw_name);
-
-                supplementaryGIDs.resize(ngroups);
-#endif
-
-                return true;
             }
 
+            if (!lockFile(fd.get(), ltWrite, false)) {
+                if (inserted) {
+                    lockedPaths_.lock()->erase(fnUserLock);
+                    continue;
+                }
+            }
+
+            fdUserLock = std::move(fd);
+            user = i;
+            uid = pw->pw_uid;
+
+            /* Sanity check... */
+            if (uid == getuid() || uid == geteuid()) {
+                throw Error(format("the Nix user should not be a member of '%1%'")
+                            % settings.buildUsersGroup);
+            }
+
+#if __linux__
+            /* Get the list of supplementary groups of this build user.  This
+               is usually either empty or contains a group such as "kvm".  */
+            supplementaryGIDs.resize(10);
+            int ngroups = supplementaryGIDs.size();
+            int err = getgrouplist(pw->pw_name, pw->pw_gid, supplementaryGIDs.data(), &ngroups);
+            if (err == -1) {
+                throw Error(format("failed to get list of supplementary groups for '%1%'") % pw->pw_name);
+            }
+
+            supplementaryGIDs.resize(ngroups);
+#endif
+
+            return true;
         } catch (...) {
-            lockedPaths_.lock()->erase(fnUserLock);
+            if (inserted) {
+                lockedPaths_.lock()->erase(fnUserLock);
+            }
+
             return false;
         }
     }

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -463,7 +463,7 @@ struct CurlDownloader : public Downloader
        pipe instead. */
     Pipe wakeupPipe;
 
-    std::thread workerThread;
+    std::jthread workerThread;
 
     CurlDownloader()
         : mt19937(rd())
@@ -484,7 +484,7 @@ struct CurlDownloader : public Downloader
         wakeupPipe.create();
         fcntl(wakeupPipe.readSide.get(), F_SETFL, O_NONBLOCK);
 
-        workerThread = std::thread([&]() { workerThreadEntry(); });
+        workerThread = std::jthread([&]() { workerThreadEntry(); });
     }
 
     ~CurlDownloader()

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -209,9 +209,9 @@ struct CurlDownloader : public Downloader
             try {
               act.progress(dlnow, dltotal);
             } catch (nix::Interrupted &) {
-              assert(_isInterrupted);
+              assert(getIsInterrupted());
             }
-            return _isInterrupted;
+            return getIsInterrupted();
         }
 
         static int progressCallbackWrapper(void * userp, double dltotal, double dlnow, double ultotal, double ulnow)
@@ -409,7 +409,7 @@ struct CurlDownloader : public Downloader
                 attempt++;
 
                 auto exc =
-                    code == CURLE_ABORTED_BY_CALLBACK && _isInterrupted
+                    code == CURLE_ABORTED_BY_CALLBACK && getIsInterrupted()
                     ? DownloadError(Interrupted, fmt("%s of '%s' was interrupted", request.verb(), request.uri))
                     : httpStatus != 0
                     ? DownloadError(err,

--- a/src/libstore/nix-store.pc.in
+++ b/src/libstore/nix-store.pc.in
@@ -6,4 +6,4 @@ Name: Nix
 Description: Nix Package Manager
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lnixstore -lnixutil
-Cflags: -I${includedir}/nix -std=c++17
+Cflags: -I${includedir}/nix -std=c++20

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -17,7 +17,7 @@ void setCurActivity(const ActivityId activityId)
     curActivity = activityId;
 }
 
-Logger * logger = makeDefaultLogger();
+std::unique_ptr<Logger> logger = makeDefaultLogger();
 
 void Logger::warn(const std::string & msg)
 {
@@ -88,9 +88,8 @@ void writeToStderr(const string & s)
     }
 }
 
-Logger * makeDefaultLogger()
-{
-    return new SimpleLogger();
+std::unique_ptr<Logger> makeDefaultLogger() {
+    return std::make_unique<SimpleLogger>();
 }
 
 std::atomic<uint64_t> nextId{(uint64_t) getpid() << 32};
@@ -168,9 +167,8 @@ struct JSONLogger : Logger
     }
 };
 
-Logger * makeJSONLogger(Logger & prevLogger)
-{
-    return new JSONLogger(prevLogger);
+std::unique_ptr<Logger> makeJSONLogger(Logger & prevLogger) {
+    return std::make_unique<JSONLogger>(prevLogger);
 }
 
 static Logger::Fields getFields(nlohmann::json & json)

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -129,11 +129,11 @@ struct PushActivity
     ~PushActivity() { setCurActivity(prevAct); }
 };
 
-extern Logger * logger;
+extern std::unique_ptr<Logger> logger;
 
-Logger * makeDefaultLogger();
+std::unique_ptr<Logger> makeDefaultLogger();
 
-Logger * makeJSONLogger(Logger & prevLogger);
+std::unique_ptr<Logger> makeJSONLogger(Logger & prevLogger);
 
 bool handleJSONLogMessage(const std::string & msg,
     const Activity & act, std::map<ActivityId, Activity> & activities,

--- a/src/libutil/monitor-fd.hh
+++ b/src/libutil/monitor-fd.hh
@@ -15,12 +15,12 @@ namespace nix {
 class MonitorFdHup
 {
 private:
-    std::thread thread;
+    std::jthread thread;
 
 public:
     MonitorFdHup(int fd)
     {
-        thread = std::thread([fd]() {
+        thread = std::jthread([fd]() {
             while (true) {
               /* Wait indefinitely until a POLLHUP occurs. */
               struct pollfd fds[1];

--- a/src/libutil/sync.hh
+++ b/src/libutil/sync.hh
@@ -44,7 +44,7 @@ public:
         friend Sync;
         Lock(Sync * s) : s(s), lk(s->mutex) { }
     public:
-        Lock(Lock && l) : s(l.s) { abort(); }
+        Lock(Lock && l) = delete;
         Lock(const Lock & l) = delete;
         ~Lock() { }
         T * operator -> () { return &s->data; }

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -23,7 +23,7 @@ ThreadPool::~ThreadPool()
 
 void ThreadPool::shutdown()
 {
-    std::vector<std::thread> workers;
+    std::vector<std::jthread> workers;
     {
         auto state(state_.lock());
         quit = true;

--- a/src/libutil/thread-pool.hh
+++ b/src/libutil/thread-pool.hh
@@ -47,7 +47,7 @@ private:
         std::queue<work_t> pending;
         size_t active = 0;
         std::exception_ptr exception;
-        std::vector<std::thread> workers;
+        std::vector<std::jthread> workers;
         bool draining = false;
     };
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1089,7 +1089,7 @@ void runProgram2(const RunOptions & options)
 
     out.writeSide.close();
 
-    std::thread writerThread;
+    std::jthread writerThread;
 
     std::promise<void> promise;
 
@@ -1101,7 +1101,7 @@ void runProgram2(const RunOptions & options)
 
     if (source) {
         in.readSide.close();
-        writerThread = std::thread([&]() {
+        writerThread = std::jthread([&]() {
             try {
                 std::vector<unsigned char> buf(8 * 1024);
                 while (true) {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -320,7 +320,8 @@ void closeOnExec(int fd);
 
 /* User interruption. */
 
-extern bool _isInterrupted;
+bool getIsInterrupted();
+void setIsInterrupted(bool value);
 
 extern thread_local std::function<bool()> interruptCheck;
 
@@ -330,7 +331,7 @@ void _interrupted();
 
 void inline checkInterrupt()
 {
-    if (_isInterrupted || (interruptCheck && interruptCheck()))
+    if (getIsInterrupted() || (interruptCheck && interruptCheck()))
         _interrupted();
 }
 

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -764,7 +764,7 @@ static void processConnection(bool trusted,
     unsigned int opCount = 0;
 
     Finally finally([&]() {
-        _isInterrupted = false;
+        setIsInterrupted(false);
         prevLogger->log(lvlDebug, fmt("%d operations", opCount));
     });
 

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -234,7 +234,7 @@ struct RetrieveRegularNARSink : ParseSink
 };
 
 
-static void performOp(TunnelLogger * logger, ref<Store> store,
+static void performOp(TunnelLogger* logger, ref<Store> store,
     bool trusted, unsigned int clientVersion,
     Source & from, Sink & to, unsigned int op)
 {
@@ -757,9 +757,9 @@ static void processConnection(bool trusted,
     if (clientVersion < 0x10a)
         throw Error("the Nix client version is too old");
 
-    auto tunnelLogger = new TunnelLogger(clientVersion);
-    auto prevLogger = nix::logger;
-    logger = tunnelLogger;
+    auto prevLogger = std::move(nix::logger);
+    logger = std::make_unique<TunnelLogger>(clientVersion);
+    auto* tunnelLogger = dynamic_cast<TunnelLogger*>(logger.get()); // wtf ...
 
     unsigned int opCount = 0;
 

--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -67,7 +67,7 @@ private:
 
     Sync<State> state_;
 
-    std::thread updateThread;
+    std::jthread updateThread;
 
     std::condition_variable quitCV, updateCV;
 
@@ -81,7 +81,7 @@ public:
         , isTTY(isTTY)
     {
         state_.lock()->active = isTTY;
-        updateThread = std::thread([&]() {
+        updateThread = std::jthread([&]() {
             auto state(state_.lock());
             while (state->active) {
                 if (!state->haveUpdate)

--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -439,14 +439,14 @@ public:
 
 void startProgressBar(bool printBuildLogs)
 {
-    logger = new ProgressBar(
+    logger = std::make_unique<ProgressBar>(
         printBuildLogs,
         isatty(STDERR_FILENO) && getEnv("TERM", "dumb") != "dumb");
 }
 
 void stopProgressBar()
 {
-    auto progressBar = dynamic_cast<ProgressBar *>(logger);
+    auto progressBar = dynamic_cast<ProgressBar*>(logger.get());
     if (progressBar) progressBar->stop();
 
 }


### PR DESCRIPTION
These fixes take care of several concurrency issues in Nix 2.3, detected mostly through TSAN.

Most importantly:

* avoid leaking threads when switching loggers around
* avoid leaking build users within a daemon process when file lock acquisition races with a neighbouring process
* avoid data races when user interrupts arrive

See individual commits for details.

These commits are currently deployed on nevsky (with TSAN still enabled).