### PR TITLE
MonitorFdHup: Make it work on macOS again

### DIFF
--- a/src/libutil/monitor-fd.hh
+++ b/src/libutil/monitor-fd.hh
@@ -22,27 +22,38 @@ public:
     {
         thread = std::jthread([fd]() {
             while (true) {
-              /* Wait indefinitely until a POLLHUP occurs. */
-              struct pollfd fds[1];
-              fds[0].fd = fd;
-              /* This shouldn't be necessary, but macOS doesn't seem to
-                 like a zeroed out events field.
-                 See rdar://37537852.
-              */
-              fds[0].events = POLLHUP;
-              auto count = poll(fds, 1, -1);
-              if (count == -1) abort(); // can't happen
-              /* This shouldn't happen, but can on macOS due to a bug.
-                 See rdar://37550628.
+                /* Wait indefinitely until a POLLHUP occurs. */
+                struct pollfd fds[1];
+                fds[0].fd = fd;
+                /* Polling for no specific events (i.e. just waiting
+                   for an error/hangup) doesn't work on macOS
+                   anymore. So wait for read events and ignore
+                   them. */
+                fds[0].events =
+                    #ifdef __APPLE__
+                    POLLRDNORM
+                    #else
+                    0
+                    #endif
+                    ;
+                auto count = poll(fds, 1, -1);
+                if (count == -1) abort(); // can't happen
+                /* This shouldn't happen, but can on macOS due to a bug.
+                   See rdar://37550628.
 
-                 This may eventually need a delay or further
-                 coordination with the main thread if spinning proves
-                 too harmful.
-               */
-              if (count == 0) continue;
-              assert(fds[0].revents & POLLHUP);
-              triggerInterrupt();
-              break;
+                   This may eventually need a delay or further
+                   coordination with the main thread if spinning proves
+                   too harmful.
+                */
+                if (count == 0) continue;
+                if (fds[0].revents & POLLHUP) {
+                    triggerInterrupt();
+                    break;
+                }
+                /* This will only happen on macOS. We sleep a bit to
+                   avoid waking up too often if the client is sending
+                   input. */
+                sleep(1);
             }
         });
     };


### PR DESCRIPTION
It appears that on current macOS versions, our use of poll() to detect client disconnects no longer works. As a workaround, poll() for POLLRDNORM, since this *will* wake up when the client has disconnected. The downside is that it also wakes up when input is available. So just sleep for a bit in that case.  This means that on macOS, a client disconnect may take up to a second to be detected, but that's better than not being detected at all.

Fixes #7584.

(cherry picked from commit 9fc8d00d741d17ff25c0193f182103d00d11582a)

Nixpkgs applied this as a patch on top of nix_2_3, so let's pick this onto our branch, so we don't see regressions for Darwin users in depot once we have to package it ourselves again.