### PR TITLE
shell.nix, release.nix: just use <nixpkgs>

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -59,7 +59,7 @@ rec {
     ]
     ++ lib.optionals stdenv.isLinux [libseccomp (pkgs.util-linuxMinimal or pkgs.utillinuxMinimal)]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-    ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
+    ++ lib.optional (false && (stdenv.isLinux || stdenv.isDarwin))
       ((aws-sdk-cpp.override {
         apis = ["s3" "transfer"];
         customMemoryManagement = false;

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 { nix ? builtins.fetchGit ./.
-, nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/nixos-21.05-small.tar.gz
+, nixpkgs ? <nixpkgs>
 , officialRelease ? false
 , systems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
 }:

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { useClang ? false }:
 
-with import (builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz) {};
+with (import <nixpkgs> {});
 
 with import ./release-common.nix { inherit pkgs; };
 


### PR DESCRIPTION
These files are irrelevant for CI as far as TVL is concerned, but may be used during development. In this case just use what the developer does as a default.