### PR TITLE
libexpr/primops: crank up our user agent

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2174,7 +2174,10 @@ void EvalState::createBaseEnv()
         addConstant("__currentSystem", v);
     }
 
-    mkString(v, nixVersion);
+    /* Set our user agent string, so we can evaluate Nixpkgs.
+       See also <https://git.lix.systems/lix-project/lix/src/commit/4a119e6e46f/lix/libexpr/builtin-constants/nixVersion.md>.
+    */
+    mkString(v, "2.18.3-tvl-cppnix-2.3-actual");
     addConstant("__nixVersion", v);
 
     mkString(v, store->storeDir);


### PR DESCRIPTION
(Edited.)

See https://github.com/NixOS/nixpkgs/commit/fa0cba1c398faad0b810555daea3bfeb05719a8c.

We'll see how dependent nixpkgs will grow on newer and features and how
feasible it is to continue using Nix 2.3.

The compat code that will be immediately removed looks like it doesn't
actually affect Nix 2.3.18 which already had some fixes backported:

- https://github.com/NixOS/nixpkgs/pull/433101. Some features of fileset
  won't work anymore, but fileset is disallowed in nixpkgs anyways.
  The documentation workaround only affects Nix < 2.3.5.
- https://github.com/NixOS/nixpkgs/pull/433055. The fix for NIX_ATTRS_*
  has been backported to Nix 2.3.18.